### PR TITLE
Expose compact doctrine history for stale UI

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -91,7 +91,7 @@ Important limit: this is not a multiplayer synchronization system. If gameplay i
 
 Every deploy increments doctrine version. Each agent tracks `deployedDoctrineVersion` and may continue running an older version until it re-enters tower range.
 
-The server stores a capped doctrine history array for correct agent-side resolution. The client only receives `previousDoctrine` for display, which is enough for basic stale indicators but not for perfect rendering of deeply stale agents.
+The server stores a capped doctrine history array for correct agent-side resolution, and the client receives a compact capped render-summary window so stale-agent UI can resolve recent versions accurately without pulling full historical doctrine payloads.
 
 ### 6. Tower sync is radius-based, not wave-based
 
@@ -170,7 +170,7 @@ These are important because future work should not accidentally assume they are 
 
 1. Auto-tick is server-owned for the single `gameWorld` actor, but multiplayer tick coordination does not exist yet.
 2. Doctrine validation is still lenient in practice despite the presence of `DOCTRINE_SCHEMA`.
-3. Client doctrine-history visibility is incomplete for agents more than one version behind.
+3. Client doctrine-history visibility is still capped, so versions older than the retained history window cannot be resolved perfectly.
 4. Threat combat is one-sided.
 5. Recovery spawning after hard death is not implemented.
 6. Micro/macro tick separation is still design intent, not code reality.
@@ -182,7 +182,7 @@ The most valuable next architectural steps are:
 1. Validate server-owned auto-tick under longer-running sessions.
 2. Add recovery spawning so hard death does not end sessions permanently.
 3. Tighten doctrine validation at deploy boundaries.
-4. Update client/server stale-doctrine representation so UI remains correct as version history grows.
+4. Validate whether the current capped doctrine-history payload remains sufficient as version history grows.
 5. Define a multiplayer tick coordinator/barrier before splitting gameplay across actors.
 
 ## Reference Docs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,7 +107,7 @@ These are true today, even if they are not the ideal long-term architecture:
 - auto-tick is scheduled by `server/src/actors/game-world.ts`
 - the client controls auto-tick through actor actions and listens for actor events
 - doctrine validation is light at deploy time and relies heavily on normalization
-- the client only receives `previousDoctrine`, not full `doctrineHistory`
+- the client receives a capped `doctrineHistory` render-summary window for stale UI; versions older than that window still cannot be resolved perfectly client-side
 - threats can damage agents, but threat neutralization is not fully implemented
 - multiplayer tick barriers/coordinators do not exist yet; current scheduling assumptions are valid only because gameplay still lives in one actor
 

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -89,7 +89,7 @@ If code and docs disagree, trust:
 - The server stores a capped doctrine history as an array of `{ version, doctrine }` entries, not a keyed map.
 - On deploy, only agents within tower `broadcastRadius` update immediately.
 - On later ticks, stale agents update when they enter tower range.
-- The client only receives `previousDoctrine`, not full history.
+- The client receives a capped `doctrineHistory` render summary containing only stale-UI fields it actually needs.
 
 ### Threats and death
 
@@ -164,8 +164,8 @@ Do not implement against speculative schema unless `shared/src/index.ts` is upda
 ### Client visibility into doctrine history is partial
 
 - Server logic can resolve agents more than one version behind using `doctrineHistory`.
-- The client cannot fully do that because it only receives `previousDoctrine`.
-- UI falls back to a neutral display for agents whose exact doctrine version is unavailable client-side.
+- The client now receives a capped `doctrineHistory` render summary window, so UI can resolve recently stale agents accurately without pulling full historical doctrine payloads.
+- UI still falls back to a neutral display if an agent somehow references a version older than the capped client history.
 
 ### Threat combat is one-sided today
 
@@ -209,7 +209,7 @@ Highest-value next milestone:
 - validate the new server-driven tick scheduling under longer play sessions
 - align repo docs with current code reality
 - strengthen doctrine validation on deploy
-- decide how much doctrine history the client should receive
+- validate whether the current capped doctrine history window is sufficient for UI needs
 - design an explicit multiplayer tick barrier/coordinator before actor decomposition
 
 ### Defer until after M2.5a unless required

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -164,7 +164,7 @@ export function App() {
             threatSightings={gameState.threatSightings ?? []}
             towers={gameState.towers ?? []}
             doctrine={gameState.doctrine}
-            previousDoctrine={gameState.previousDoctrine}
+            doctrineHistory={gameState.doctrineHistory ?? []}
           />
           <GameControls
             onTick={handleTick}
@@ -182,7 +182,7 @@ export function App() {
             debrief={latestDebrief}
             agents={gameState.agents}
             doctrine={gameState.doctrine}
-            previousDoctrine={gameState.previousDoctrine}
+            doctrineHistory={gameState.doctrineHistory ?? []}
             threatSightings={gameState.threatSightings ?? []}
           />
         </div>

--- a/client/src/components/MapView.tsx
+++ b/client/src/components/MapView.tsx
@@ -1,5 +1,15 @@
 import React from "react";
-import type { Agent, Doctrine, GameMap, Position, Threat, ThreatSighting, Tower } from "@doctrine/shared";
+import { resolveDoctrineMaxEpisodes } from "@doctrine/shared";
+import type {
+  Agent,
+  Doctrine,
+  DoctrineRenderSummary,
+  GameMap,
+  Position,
+  Threat,
+  ThreatSighting,
+  Tower,
+} from "@doctrine/shared";
 
 interface MapViewProps {
   map: GameMap;
@@ -10,7 +20,7 @@ interface MapViewProps {
   threatSightings: ThreatSighting[];
   towers: Tower[];
   doctrine: Doctrine;
-  previousDoctrine: Doctrine | null;
+  doctrineHistory: DoctrineRenderSummary[];
 }
 
 const TILE_SIZE = 22;
@@ -34,27 +44,36 @@ const STACKED_AGENT_OFFSETS = [
   { dx: 5, dy: 5 },
 ];
 
-function memoryLoad(agent: Agent, doctrine: Doctrine, previousDoctrine: Doctrine | null): number {
-  // Resolve the doctrine this agent is actually running on the server
-  const agentDoctrine =
-    agent.deployedDoctrineVersion === doctrine.version ? doctrine :
-    agent.deployedDoctrineVersion === previousDoctrine?.version ? previousDoctrine :
-    null; // version too old — not available on client; show neutral ring
+function memoryLoad(
+  agent: Agent,
+  doctrine: Doctrine,
+  doctrineHistory: DoctrineRenderSummary[],
+): number {
+  const maxEpisodes = resolveDoctrineMaxEpisodes(
+    doctrine,
+    doctrineHistory,
+    agent.type,
+    agent.deployedDoctrineVersion,
+  );
 
-  if (!agentDoctrine) return 0.3;
-
-  let maxEpisodes: number;
-  if (agent.type === "gatherer") maxEpisodes = agentDoctrine.gatherer.memory.maxEpisodes;
-  else if (agent.type === "scout") maxEpisodes = agentDoctrine.scout.memory.maxEpisodes;
-  else if (agent.type === "defender") maxEpisodes = agentDoctrine.defender.memory.maxEpisodes;
-  else maxEpisodes = 10;
+  if (maxEpisodes === null) return 0.3;
 
   // Unlimited (maxEpisodes=0): scale by a fixed cap so the ring remains informative
   if (maxEpisodes === 0) return agent.episodes.length > 0 ? Math.min(1, agent.episodes.length / 50) : 0;
   return Math.min(1, agent.episodes.length / maxEpisodes);
 }
 
-export function MapView({ map, agents, basePosition, currentTick, threats, threatSightings, towers, doctrine, previousDoctrine }: MapViewProps) {
+export function MapView({
+  map,
+  agents,
+  basePosition,
+  currentTick,
+  threats,
+  threatSightings,
+  towers,
+  doctrine,
+  doctrineHistory,
+}: MapViewProps) {
   if (!map) return null;
 
   const width = map.width * TILE_SIZE;
@@ -257,7 +276,11 @@ export function MapView({ map, agents, basePosition, currentTick, threats, threa
         })}
 
         {/* Agents — offset stacked agents so all are visible */}
-        <AgentMarkers agents={agents} doctrine={doctrine} previousDoctrine={previousDoctrine} />
+        <AgentMarkers
+          agents={agents}
+          doctrine={doctrine}
+          doctrineHistory={doctrineHistory}
+        />
       </svg>
 
       {threatSightings.length > 0 && (
@@ -280,11 +303,11 @@ export function MapView({ map, agents, basePosition, currentTick, threats, threa
 function AgentMarkers({
   agents,
   doctrine,
-  previousDoctrine,
+  doctrineHistory,
 }: {
   agents: Agent[];
   doctrine: Doctrine;
-  previousDoctrine: Doctrine | null;
+  doctrineHistory: DoctrineRenderSummary[];
 }) {
   const tileCounts = new Map<string, number>();
   const tileSlot = new Map<string, number>();
@@ -304,7 +327,7 @@ function AgentMarkers({
     const cy = agent.position.y * TILE_SIZE + TILE_SIZE / 2 + offset.dy;
     const color = AGENT_COLORS[agent.type];
     const r = 5;
-    const load = memoryLoad(agent, doctrine, previousDoctrine);
+    const load = memoryLoad(agent, doctrine, doctrineHistory);
 
     return (
       <g key={agent.id}>

--- a/client/src/components/TickDebriefPanel.tsx
+++ b/client/src/components/TickDebriefPanel.tsx
@@ -1,12 +1,21 @@
 import React, { useMemo, useState } from "react";
 import clsx from "clsx";
-import type { Agent, AgentAction, Doctrine, EpisodeEventType, ThreatSighting, TickDebrief } from "@doctrine/shared";
+import { resolveDoctrineMaxEpisodes } from "@doctrine/shared";
+import type {
+  Agent,
+  AgentAction,
+  Doctrine,
+  DoctrineRenderSummary,
+  EpisodeEventType,
+  ThreatSighting,
+  TickDebrief,
+} from "@doctrine/shared";
 
 interface TickDebriefPanelProps {
   debrief: TickDebrief | null;
   agents: Agent[];
   doctrine: Doctrine | null;
-  previousDoctrine: Doctrine | null;
+  doctrineHistory: DoctrineRenderSummary[];
   threatSightings: ThreatSighting[];
 }
 
@@ -42,7 +51,13 @@ const EVENT_COLORS: Record<EpisodeEventType, string> = {
   "damage-taken": "var(--color-error)",
 };
 
-export function TickDebriefPanel({ debrief, agents, doctrine, previousDoctrine, threatSightings }: TickDebriefPanelProps) {
+export function TickDebriefPanel({
+  debrief,
+  agents,
+  doctrine,
+  doctrineHistory,
+  threatSightings,
+}: TickDebriefPanelProps) {
   const [expandedAgentId, setExpandedAgentId] = useState<string | null>(null);
   const agentById = useMemo(() => new Map(agents.map((a) => [a.id, a])), [agents]);
 
@@ -59,16 +74,13 @@ export function TickDebriefPanel({ debrief, agents, doctrine, previousDoctrine, 
   const staleAgents = agents.filter((a) => a.deployedDoctrineVersion < currentVersion);
 
   function getMaxEpisodes(agent: Agent): number | null {
-    // Resolve the doctrine version this agent is actually running on the server
-    const agentDoctrine =
-      agent.deployedDoctrineVersion === doctrine?.version ? doctrine :
-      agent.deployedDoctrineVersion === previousDoctrine?.version ? previousDoctrine :
-      null; // version too old — not available on client
-    if (!agentDoctrine) return null;
-    if (agent.type === "gatherer") return agentDoctrine.gatherer.memory.maxEpisodes;
-    if (agent.type === "scout") return agentDoctrine.scout.memory.maxEpisodes;
-    if (agent.type === "defender") return agentDoctrine.defender.memory.maxEpisodes;
-    return null;
+    if (!doctrine) return null;
+    return resolveDoctrineMaxEpisodes(
+      doctrine,
+      doctrineHistory,
+      agent.type,
+      agent.deployedDoctrineVersion,
+    );
   }
 
   return (

--- a/memory/project_m2_next_steps.md
+++ b/memory/project_m2_next_steps.md
@@ -11,7 +11,7 @@ M2 is implemented and typechecks clean.
 - Tier 2 Episodic Memory: agents accumulate EpisodeRecord[] for resource-found, resource-depleted, task-completed, threat-spotted, damage-taken events
 - Memory decay: configurable `maxEpisodes` + `decayAfterTicks` per agent type in doctrine
 - Tower broadcasting: 1 initial tower at base with radius 8; when doctrine is deployed, only in-range agents update immediately; out-of-range agents sync each tick as they enter tower range
-- Per-agent doctrine versioning: each agent carries `deployedDoctrineVersion`; agents resolve their doctrine config via `doctrineHistory` (keyed by version, capped at 5 entries) so agents 2+ versions behind still use the right config; `previousDoctrine` is UI-only (most recent prior doctrine for display); debrief shows version skew with orange indicator dot in MapView and "VERSION SKEW" warning in debrief
+- Per-agent doctrine versioning: each agent carries `deployedDoctrineVersion`; agents resolve their doctrine config via `doctrineHistory` (keyed by version, capped at 5 entries) so agents 2+ versions behind still use the right config; the client only receives a compact render-summary view of that history for stale UI; debrief shows version skew with orange indicator dot in MapView and "VERSION SKEW" warning in debrief
 - Threats: hostile units spawn every 20 ticks (max 3 at once) at map edges, move toward nearest agent, deal 1 damage on contact
 - Hard death: when agent hp <= 0, removed from game — episodic memory is gone; "FALLEN: agent-id" notice in debrief
 - MapView: renders towers (T glyph), threat radius ring, threats (X glyph), memory load ring on agents (grows with experience), orange dot for stale doctrine version

--- a/server/src/__tests__/game-world.test.ts
+++ b/server/src/__tests__/game-world.test.ts
@@ -132,6 +132,42 @@ describe("getPublicState", () => {
     expect(state.autoTick).toBe(true);
     expect(state.tickIntervalMs).toBe(750);
   });
+
+  it("exposes capped doctrine history so clients can resolve stale agent versions", () => {
+    const v1 = makeDoctrine({ version: 1, scout: { ...makeDoctrine().scout, memory: { maxEpisodes: 7, decayAfterTicks: 10 } } });
+    const v2 = makeDoctrine({ version: 2, scout: { ...makeDoctrine().scout, memory: { maxEpisodes: 11, decayAfterTicks: 20 } } });
+    const state = getPublicState({
+      phase: "running",
+      tick: 4,
+      autoTick: false,
+      tickIntervalMs: 1000,
+      map: makeMap(),
+      agents: [makeAgent("scout-0", "scout", { x: 16, y: 12 }, { deployedDoctrineVersion: 1 })],
+      doctrine: makeDoctrine({ version: 3 }),
+      doctrineHistory: [
+        { version: 1, doctrine: v1 },
+        { version: 2, doctrine: v2 },
+      ],
+      basePosition: { x: 16, y: 12 },
+      totalResourcesCollected: 0,
+      debriefs: [],
+      knownResources: [],
+      threats: [],
+      threatSightings: [],
+      towers: [makeTower("tower-0", { x: 16, y: 12 })],
+    });
+
+    expect(state.doctrineHistory).toEqual([
+      {
+        version: 1,
+        memoryMaxEpisodes: { gatherer: v1.gatherer.memory.maxEpisodes, scout: 7, defender: v1.defender.memory.maxEpisodes },
+      },
+      {
+        version: 2,
+        memoryMaxEpisodes: { gatherer: v2.gatherer.memory.maxEpisodes, scout: 11, defender: v2.defender.memory.maxEpisodes },
+      },
+    ]);
+  });
 });
 
 describe("auto-tick generation helpers", () => {
@@ -234,6 +270,21 @@ describe("gameWorld executeTick", () => {
     expect(result.state.threatSightings).toEqual([
       { threatId: "threat-0", position: { x: 18, y: 12 }, lastSeenTick: 5 },
     ]);
+  });
+
+  it("returns doctrine history after multiple deploys for deeply stale clients", async (c) => {
+    const { client } = await setupTest(c, registry);
+    const handle = client.gameWorld.getOrCreate(["public-doctrine-history"]);
+
+    await handle.initGame(123);
+    await handle.deployDoctrine(makeDoctrine({ name: "v2" }));
+    await handle.deployDoctrine(makeDoctrine({ name: "v3" }));
+
+    const state = await handle.getState();
+
+    expect(state.doctrine.version).toBe(3);
+    expect(state.doctrineHistory.map((entry) => entry.version)).toEqual([1, 2]);
+    expect(state.doctrineHistory[0]?.memoryMaxEpisodes.scout).toBe(20);
   });
 
   it("invalidates stale scheduled ticks after auto-tick is stopped", async (c) => {

--- a/server/src/actors/game-world.ts
+++ b/server/src/actors/game-world.ts
@@ -4,6 +4,8 @@ import type {
   AgentAction,
   AgentType,
   Doctrine,
+  DoctrineHistoryEntry,
+  DoctrineRenderSummary,
   EpisodeRecord,
   GameMap,
   GamePhase,
@@ -14,7 +16,7 @@ import type {
   ThreatSighting,
   Tower,
 } from "@doctrine/shared";
-import { DEFAULT_DOCTRINE } from "@doctrine/shared";
+import { DEFAULT_DOCTRINE, summarizeDoctrineForRender } from "@doctrine/shared";
 import { generateMap } from "../engine/map-generator.js";
 import {
   THREAT_SIGHTING_EXPIRY_TICKS,
@@ -122,7 +124,7 @@ export type GameWorldRuntimeState = {
   map: GameMap | null;
   agents: Agent[];
   doctrine: Doctrine;
-  doctrineHistory: Array<{ version: number; doctrine: Doctrine }>;
+  doctrineHistory: DoctrineHistoryEntry[];
   basePosition: Position;
   totalResourcesCollected: number;
   debriefs: TickDebrief[];
@@ -247,7 +249,7 @@ export const gameWorld = actor({
     agents: [] as Agent[],
     doctrine: DEFAULT_DOCTRINE as Doctrine,
     /** Normalized history of past doctrine versions, keyed by version. Capped at 5 entries. */
-    doctrineHistory: [] as Array<{ version: number; doctrine: Doctrine }>,
+    doctrineHistory: [] as DoctrineHistoryEntry[],
     basePosition: DEFAULT_DOCTRINE.basePosition,
     totalResourcesCollected: 0,
     debriefs: [] as TickDebrief[],
@@ -348,7 +350,7 @@ export const gameWorld = actor({
         }
       }
 
-      // Broadcast full public state so clients immediately see previousDoctrine,
+      // Broadcast full public state so clients immediately see compact doctrine history,
       // updated agent deployedDoctrineVersions, and the new doctrine together.
       c.broadcast("doctrineDeployed", getPublicState(c.state));
       return c.state.doctrine;
@@ -560,7 +562,7 @@ function runTick(
   tick: number,
   agents: Agent[],
   doctrine: Doctrine,
-  doctrineHistory: Array<{ version: number; doctrine: Doctrine }>,
+  doctrineHistory: DoctrineHistoryEntry[],
   map: GameMap,
   knownResources: Position[],
   threatSightings: ThreatSighting[],
@@ -637,7 +639,7 @@ function runTick(
 function resolveDoctrineForAgent(
   agent: Agent,
   current: Doctrine,
-  history: Array<{ version: number; doctrine: Doctrine }>,
+  history: DoctrineHistoryEntry[],
 ): Doctrine {
   if (agent.deployedDoctrineVersion === current.version) return current;
   return history.find((h) => h.version === agent.deployedDoctrineVersion)?.doctrine ?? current;
@@ -680,7 +682,7 @@ export function getPublicState(state: {
   map: GameMap | null;
   agents: Agent[];
   doctrine: Doctrine;
-  doctrineHistory: Array<{ version: number; doctrine: Doctrine }>;
+  doctrineHistory: DoctrineHistoryEntry[];
   basePosition: { x: number; y: number };
   totalResourcesCollected: number;
   debriefs: TickDebrief[];
@@ -689,8 +691,6 @@ export function getPublicState(state: {
   threatSightings: ThreatSighting[];
   towers: Tower[];
 }): GameState {
-  // Expose the most-recent historical doctrine as previousDoctrine for the client UI
-  const previousDoctrine = (state.doctrineHistory ?? []).at(-1)?.doctrine ?? null;
   return {
     phase: state.phase,
     tick: state.tick,
@@ -699,7 +699,7 @@ export function getPublicState(state: {
     map: state.map!,
     agents: state.agents,
     doctrine: normalizeDoctrine(state.doctrine),
-    previousDoctrine,
+    doctrineHistory: state.doctrineHistory.map((entry): DoctrineRenderSummary => summarizeDoctrineForRender(entry.doctrine)),
     basePosition: state.basePosition,
     totalResourcesCollected: state.totalResourcesCollected,
     debriefs: state.debriefs,

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -181,6 +181,40 @@ export interface Doctrine {
   basePosition: Position;
 }
 
+export interface DoctrineHistoryEntry {
+  version: number;
+  doctrine: Doctrine;
+}
+
+export interface DoctrineRenderSummary {
+  version: number;
+  memoryMaxEpisodes: Record<AgentType, number>;
+}
+
+export function summarizeDoctrineForRender(doctrine: Doctrine): DoctrineRenderSummary {
+  return {
+    version: doctrine.version,
+    memoryMaxEpisodes: {
+      gatherer: doctrine.gatherer.memory.maxEpisodes,
+      scout: doctrine.scout.memory.maxEpisodes,
+      defender: doctrine.defender.memory.maxEpisodes,
+    },
+  };
+}
+
+export function resolveDoctrineMaxEpisodes(
+  currentDoctrine: Doctrine,
+  doctrineHistory: DoctrineRenderSummary[],
+  agentType: AgentType,
+  version: number,
+): number | null {
+  if (version === currentDoctrine.version) {
+    return summarizeDoctrineForRender(currentDoctrine).memoryMaxEpisodes[agentType];
+  }
+
+  return doctrineHistory.find((entry) => entry.version === version)?.memoryMaxEpisodes[agentType] ?? null;
+}
+
 // --- Tick & Debrief ---
 
 export interface AgentAction {
@@ -218,8 +252,8 @@ export interface GameState {
   map: GameMap;
   agents: Agent[];
   doctrine: Doctrine;
-  /** Most recent prior doctrine — exposed for UI display only. Agent version resolution uses doctrineHistory on the server. */
-  previousDoctrine: Doctrine | null;
+  /** Capped doctrine history summary exposed for stale-version UI rendering. */
+  doctrineHistory: DoctrineRenderSummary[];
   basePosition: Position;
   totalResourcesCollected: number;
   debriefs: TickDebrief[];


### PR DESCRIPTION
Closes #5 
## Summary
- expose a compact doctrine render-history payload for stale-version UI instead of full historical doctrine objects
- update map and debrief stale rendering to resolve memory caps from the compact history summaries
- add server tests and doc updates covering the reduced payload shape and issue #5 follow-up