### PR TITLE
feat: add defender threat neutralization

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -103,11 +103,11 @@ Current tower behavior is simple:
 
 Wave propagation, pulse timing, tower construction, and conflict resolution are not implemented yet.
 
-### 7. Threats are hazards more than full combat units
+### 7. Threat combat is intentionally lightweight
 
-Threats spawn, move toward agents, and deal contact damage. Defenders can chase them, but agents do not yet have a fully implemented attack/removal path against threats.
+Threats spawn, move toward the nearest agent, and deal contact damage. Defenders can chase them and neutralize them with simple melee attacks once they close to range 1.
 
-That means the threat model currently supports pressure and hard death, but not complete combat resolution.
+This keeps the prototype deterministic and testable without introducing a broader combat stat system yet.
 
 ## Current Runtime Flow
 
@@ -171,7 +171,7 @@ These are important because future work should not accidentally assume they are 
 1. Auto-tick is server-owned for the single `gameWorld` actor, but multiplayer tick coordination does not exist yet.
 2. Doctrine validation is still lenient in practice despite the presence of `DOCTRINE_SCHEMA`.
 3. Client doctrine-history visibility is still capped, so versions older than the retained history window cannot be resolved perfectly.
-4. Threat combat is one-sided.
+4. Threat combat is still minimal and defender-only.
 5. Recovery spawning after hard death is not implemented.
 6. Micro/macro tick separation is still design intent, not code reality.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,9 +106,10 @@ These are true today, even if they are not the ideal long-term architecture:
 
 - auto-tick is scheduled by `server/src/actors/game-world.ts`
 - the client controls auto-tick through actor actions and listens for actor events
+- for gameplay verification, prefer manual tick execution over auto-tick so behavior and UI outcomes are reproducible; use auto-tick mainly for longer soak checks
 - doctrine validation is light at deploy time and relies heavily on normalization
 - the client receives a capped `doctrineHistory` render-summary window for stale UI; versions older than that window still cannot be resolved perfectly client-side
-- threats can damage agents, but threat neutralization is not fully implemented
+- threats can damage agents and defenders can neutralize them with simple melee combat; broader combat systems are not implemented
 - multiplayer tick barriers/coordinators do not exist yet; current scheduling assumptions are valid only because gameplay still lives in one actor
 
 Do not write docs or code as if those problems are already solved.

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -96,6 +96,8 @@ If code and docs disagree, trust:
 - Threats spawn every 20 ticks up to a max of 3.
 - Threats path toward the nearest agent.
 - Threats deal 1 damage on contact.
+- Defenders can neutralize threats with a 1-damage melee attack at range 1.
+- Neutralized threats are removed before the threat movement/damage step resolves.
 - Dead agents are removed from the world.
 - Debrief emits `FALLEN` notices.
 
@@ -167,12 +169,11 @@ Do not implement against speculative schema unless `shared/src/index.ts` is upda
 - The client now receives a capped `doctrineHistory` render summary window, so UI can resolve recently stale agents accurately without pulling full historical doctrine payloads.
 - UI still falls back to a neutral display if an agent somehow references a version older than the capped client history.
 
-### Threat combat is one-sided today
+### Threat combat is prototype-simple, not fully systemic
 
-- Threats can damage agents.
-- Defenders can chase threats.
-- No agent attack/damage/removal path for threats is implemented yet.
-- In practice, threats are persistent hazards rather than fully modeled combatants.
+- Threats can damage agents on contact.
+- Defenders can chase nearby threats and neutralize them with melee attacks.
+- Combat is still intentionally lightweight: only defenders attack, there are no ranged attacks, and threat behavior is still nearest-agent pursuit.
 
 ---
 
@@ -202,7 +203,7 @@ Highest-value next milestone:
 - add deployment/spawn schema to `shared/src/index.ts`
 - implement replacement spawning from base
 - surface spawn queue in the debrief/UI
-- define threat/combat behavior clearly enough to test sustained play
+- tune threat/combat balance under sustained play
 
 ### Infrastructure cleanup that should happen soon
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Run from repository root:
 - Shared types in `shared/src/index.ts` are the source of truth for server-client contracts.
 - Map generation and agent decisions are deterministic (no runtime randomness in engine logic).
 - Auto-tick is now scheduled by `server/src/actors/game-world.ts`; the client only issues start/stop/interval control actions.
+- For gameplay verification and UI checks, prefer manual ticks over auto-tick so outcomes stay reproducible; use auto-tick mainly for longer soak checks.
 - This solves overlap for the current single-actor sim, but it is not yet a multiplayer tick barrier. If simulation is later split across multiple actors or players, a coordinator/ack design will be required.
 
 For current implementation details, see `HANDOFF.md`.

--- a/client/src/components/MapView.tsx
+++ b/client/src/components/MapView.tsx
@@ -417,6 +417,7 @@ function renderAgentShape(cx: number, cy: number, r: number, status: string, col
         />
       );
     case "defending":
+    case "attacking":
       return (
         <rect
           x={cx - r + 1}

--- a/client/src/components/TickDebriefPanel.tsx
+++ b/client/src/components/TickDebriefPanel.tsx
@@ -22,6 +22,7 @@ interface TickDebriefPanelProps {
 const ACTION_ICONS: Record<string, string> = {
   move: ">",
   "move-intel": "»",
+  attack: "x",
   gather: "+",
   deposit: "$",
   observe: "?",
@@ -41,6 +42,7 @@ const EVENT_ICONS: Record<EpisodeEventType, string> = {
   "task-completed": "✓",
   "threat-spotted": "!",
   "damage-taken": "✕",
+  "threat-neutralized": "x",
 };
 
 const EVENT_COLORS: Record<EpisodeEventType, string> = {
@@ -49,6 +51,7 @@ const EVENT_COLORS: Record<EpisodeEventType, string> = {
   "task-completed": "var(--color-info)",
   "threat-spotted": "var(--color-warning)",
   "damage-taken": "var(--color-error)",
+  "threat-neutralized": "var(--color-success)",
 };
 
 export function TickDebriefPanel({
@@ -72,6 +75,12 @@ export function TickDebriefPanel({
 
   const currentVersion = doctrine?.version ?? 1;
   const staleAgents = agents.filter((a) => a.deployedDoctrineVersion < currentVersion);
+  const notices = debrief.notices ?? [];
+  const threatDownNotices = notices.filter((notice) => notice.startsWith("THREAT DOWN:"));
+  const threatDownIds = threatDownNotices.map((notice) =>
+    notice.replace(/^THREAT DOWN:\s*/, "").replace(/ neutralized by defenders$/, ""),
+  );
+  const otherNotices = notices.filter((notice) => !notice.startsWith("THREAT DOWN:"));
 
   function getMaxEpisodes(agent: Agent): number | null {
     if (!doctrine) return null;
@@ -99,6 +108,22 @@ export function TickDebriefPanel({
           ! VERSION SKEW: {staleAgents.map((a) => `${a.id} (v${a.deployedDoctrineVersion})`).join(", ")} running old doctrine
         </div>
       )}
+      {threatDownIds.length > 0 && (
+        <div className="debrief-threat-down">
+          <div className="debrief-threat-down-label">THREAT DOWN</div>
+          <div className="debrief-threat-down-summary">
+            {threatDownIds.length} {threatDownIds.length === 1 ? "hostile neutralized" : "hostiles neutralized"} this tick
+          </div>
+          <div className="debrief-threat-down-list">
+            {threatDownIds.map((threatId) => (
+              <div key={threatId} className="debrief-threat-down-entry">
+                <span className="debrief-threat-down-icon">x</span>
+                <span className="debrief-threat-down-id">{threatId}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
       {threatSightings.length > 0 && (
         <div className="debrief-threat-intel">
           <div className="debrief-threat-intel-label">THREAT INTEL</div>
@@ -113,9 +138,9 @@ export function TickDebriefPanel({
           </div>
         </div>
       )}
-      {debrief.notices && debrief.notices.length > 0 && (
+      {otherNotices.length > 0 && (
         <div className="debrief-notices">
-          {debrief.notices.map((notice, i) => (
+          {otherNotices.map((notice, i) => (
             <div key={`${i}-${notice}`} className={`debrief-notice ${notice.startsWith("FALLEN") ? "debrief-notice-fallen" : ""}`}>
               ! {notice}
             </div>

--- a/client/src/styles/index.css
+++ b/client/src/styles/index.css
@@ -469,6 +469,51 @@ body {
   border-bottom: 1px solid var(--border);
 }
 
+.debrief-threat-down {
+  padding: 10px 16px 12px;
+  border-bottom: 1px solid var(--border);
+  background: color-mix(in srgb, var(--color-success) 8%, transparent);
+}
+
+.debrief-threat-down-label {
+  font-size: 10px;
+  letter-spacing: 2px;
+  color: var(--color-success);
+  margin-bottom: 4px;
+}
+
+.debrief-threat-down-summary {
+  font-size: 12px;
+  color: var(--text-primary);
+  margin-bottom: 8px;
+}
+
+.debrief-threat-down-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.debrief-threat-down-entry {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+  border: 1px solid color-mix(in srgb, var(--color-success) 30%, var(--border));
+  background: color-mix(in srgb, var(--color-success) 12%, transparent);
+  font-size: 11px;
+  font-family: var(--font-mono);
+}
+
+.debrief-threat-down-icon {
+  color: var(--color-success);
+  font-weight: 700;
+}
+
+.debrief-threat-down-id {
+  color: var(--text-primary);
+}
+
 .debrief-threat-intel {
   padding: 8px 16px 10px;
   border-bottom: 1px solid var(--border);

--- a/server/src/__tests__/agent-logic.test.ts
+++ b/server/src/__tests__/agent-logic.test.ts
@@ -329,6 +329,22 @@ describe("defender threat behavior", () => {
     expect(action.reason).toContain("Engaging threat");
   });
 
+  it("attacks an adjacent visible threat instead of moving into it", () => {
+    const map = makeMap();
+    const agent = makeAgent("defender-0", "defender", { x: 16, y: 12 });
+    const threat = makeThreat("threat-0", { x: 17, y: 12 });
+    const doctrine = makeDoctrine({
+      defender: { ...makeDoctrine().defender, chaseThreats: true, maxChaseDistance: 6 },
+    });
+    const pending: Array<{ agentId: string; record: EpisodeRecord }> = [];
+
+    const action = executeAgent(agent, doctrine, map, 1, [], [], [threat], pending);
+
+    expect(action.action).toBe("attack");
+    expect(action.targetThreatId).toBe("threat-0");
+    expect(action.to).toMatchObject({ x: 17, y: 12 });
+  });
+
   it("records threat-spotted episode on first sighting", () => {
     const map = makeMap();
     const agent = makeAgent("defender-0", "defender", { x: 16, y: 12 });
@@ -385,7 +401,7 @@ describe("defender threat behavior", () => {
   it("holds position when chaseThreats=false even with visible threat", () => {
     const map = makeMap();
     const agent = makeAgent("defender-0", "defender", { x: 16, y: 12 });
-    const threat = makeThreat("threat-0", { x: 17, y: 12 });
+    const threat = makeThreat("threat-0", { x: 18, y: 12 });
     const doctrine = makeDoctrine({
       defender: { ...makeDoctrine().defender, chaseThreats: false, guardRadius: 4 },
     });
@@ -394,6 +410,21 @@ describe("defender threat behavior", () => {
     const action = executeAgent(agent, doctrine, map, 1, [], [], [threat], pending);
 
     expect(action.action).toBe("guard");
+  });
+
+  it("still attacks a threat already in melee range when chaseThreats=false", () => {
+    const map = makeMap();
+    const agent = makeAgent("defender-0", "defender", { x: 16, y: 12 });
+    const threat = makeThreat("threat-0", { x: 17, y: 12 });
+    const doctrine = makeDoctrine({
+      defender: { ...makeDoctrine().defender, chaseThreats: false, guardRadius: 4 },
+    });
+    const pending: Array<{ agentId: string; record: EpisodeRecord }> = [];
+
+    const action = executeAgent(agent, doctrine, map, 1, [], [], [threat], pending);
+
+    expect(action.action).toBe("attack");
+    expect(action.targetThreatId).toBe("threat-0");
   });
 
   it("ignores threats beyond maxChaseDistance", () => {
@@ -703,6 +734,70 @@ describe("applyAction", () => {
     expect(agent.position).toMatchObject({ x: 15, y: 12 });
     expect(pending.find((e) => e.record.eventType === "task-completed")?.record.position).toMatchObject({ x: 15, y: 12 });
   });
+
+  it("damages the targeted threat when attacking", () => {
+    const map = makeMap();
+    const agent = makeAgent("defender-0", "defender", { x: 16, y: 12 });
+    const threat = makeThreat("threat-0", { x: 17, y: 12 });
+    const pending: Array<{ agentId: string; record: EpisodeRecord }> = [];
+
+    applyAction(
+      {
+        agentId: "defender-0",
+        agentType: "defender",
+        action: "attack",
+        reason: "",
+        from: { x: 16, y: 12 },
+        to: { x: 17, y: 12 },
+        targetThreatId: "threat-0",
+        doctrineVersion: 1,
+      },
+      [agent],
+      map,
+      1,
+      pending,
+      [threat],
+    );
+
+    expect(agent.status).toBe("attacking");
+    expect(threat.hp).toBe(2);
+  });
+
+  it("records threat-neutralized when an attack lands the killing blow", () => {
+    const map = makeMap();
+    const agent = makeAgent("defender-0", "defender", { x: 16, y: 12 }, {
+      workingMemory: {
+        currentTask: "chase:threat-0",
+        taskTarget: { x: 17, y: 12 },
+        taskStartTick: 1,
+      },
+    });
+    const threat = makeThreat("threat-0", { x: 17, y: 12 });
+    threat.hp = 1;
+    const pending: Array<{ agentId: string; record: EpisodeRecord }> = [];
+
+    applyAction(
+      {
+        agentId: "defender-0",
+        agentType: "defender",
+        action: "attack",
+        reason: "",
+        from: { x: 16, y: 12 },
+        to: { x: 17, y: 12 },
+        targetThreatId: "threat-0",
+        doctrineVersion: 1,
+      },
+      [agent],
+      map,
+      2,
+      pending,
+      [threat],
+    );
+
+    expect(threat.hp).toBe(0);
+    expect(agent.workingMemory.currentTask).toBeNull();
+    expect(pending.some((e) => e.record.eventType === "threat-neutralized")).toBe(true);
+  });
 });
 
 // ============================================================
@@ -870,6 +965,28 @@ describe("threat mechanics", () => {
     moveThreat(threat, [], map);
 
     expect(threat.position).toMatchObject(originalPos);
+  });
+
+  it("does not let a neutralized threat move or damage agents later in the tick", () => {
+    const map = makeMap();
+    const defender = makeAgent("defender-0", "defender", { x: 16, y: 12 });
+    const gatherer = makeAgent("gatherer-0", "gatherer", { x: 18, y: 12 }, { hp: 5, maxHp: 5 });
+    const threat = makeThreat("threat-0", { x: 17, y: 12 });
+    threat.hp = 1;
+    const pending: Array<{ agentId: string; record: EpisodeRecord }> = [];
+
+    const action = executeAgent(defender, makeDoctrine(), map, 1, [], [], [threat], pending);
+    expect(action.action).toBe("attack");
+
+    applyAction(action, [defender, gatherer], map, 1, pending, [threat]);
+    const activeThreats = threat.hp > 0 ? [threat] : [];
+    for (const activeThreat of activeThreats) {
+      moveThreat(activeThreat, [defender, gatherer], map);
+    }
+    applyThreatDamage(activeThreats, [defender, gatherer], 1, pending);
+
+    expect(activeThreats).toHaveLength(0);
+    expect(gatherer.hp).toBe(5);
   });
 });
 

--- a/server/src/__tests__/game-world.test.ts
+++ b/server/src/__tests__/game-world.test.ts
@@ -272,6 +272,48 @@ describe("gameWorld executeTick", () => {
     ]);
   });
 
+  it("removes a neutralized threat before threat movement and cleans up its intel", async (c) => {
+    const { client } = await setupTest(c, registry);
+    const handle = client.gameWorld.getOrCreate(["execute-tick-threat-neutralization"]);
+
+    await handle.initGame(123);
+
+    const gatewayUrl = await handle.getGatewayUrl();
+    const stateResponse = await fetch(`${gatewayUrl}/inspector/state`, {
+      headers: { Authorization: "Bearer token" },
+    });
+    expect(stateResponse.status).toBe(200);
+
+    const inspectorPayload = (await stateResponse.json()) as { state: GameWorldRuntimeState };
+    const actorState = inspectorPayload.state;
+    actorState.tick = 4;
+    actorState.agents = [
+      makeAgent("defender-0", "defender", { x: 16, y: 12 }),
+      makeAgent("gatherer-0", "gatherer", { x: 18, y: 12 }, { hp: 5, maxHp: 5 }),
+    ];
+    actorState.threats = [makeThreat("threat-0", { x: 17, y: 12 })];
+    actorState.threats[0].hp = 1;
+    actorState.threatSightings = [{ threatId: "threat-0", position: { x: 17, y: 12 }, lastSeenTick: 4 }];
+
+    const patchResponse = await fetch(`${gatewayUrl}/inspector/state`, {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer token",
+      },
+      body: JSON.stringify({ state: actorState }),
+    });
+    expect(patchResponse.status).toBe(200);
+
+    const result = await handle.executeTick();
+
+    expect(result.state.tick).toBe(5);
+    expect(result.state.threats).toEqual([]);
+    expect(result.state.threatSightings).toEqual([]);
+    expect(result.state.agents.find((agent) => agent.id === "gatherer-0")?.hp).toBe(5);
+    expect(result.debrief.notices).toContain("THREAT DOWN: threat-0 neutralized by defenders");
+  });
+
   it("returns doctrine history after multiple deploys for deeply stale clients", async (c) => {
     const { client } = await setupTest(c, registry);
     const handle = client.gameWorld.getOrCreate(["public-doctrine-history"]);

--- a/server/src/actors/game-world.ts
+++ b/server/src/actors/game-world.ts
@@ -464,7 +464,7 @@ function executeWorldTick(c: {
     c.state.threats.push(spawnThreat(threatId, c.state.map, c.state.seed));
   }
 
-  const { debrief, newKnownResources, newThreatSightings, killedAgentIds } = runTick(
+  const { debrief, newKnownResources, newThreatSightings, killedAgentIds, neutralizedThreatIds } = runTick(
     c.state.tick,
     c.state.agents,
     c.state.doctrine,
@@ -492,6 +492,12 @@ function executeWorldTick(c: {
   });
   c.state.knownResources = cleanedIntel.knownResources;
   c.state.threatSightings = cleanedIntel.threatSightings;
+
+  if (neutralizedThreatIds.length > 0) {
+    debrief.notices.push(
+      ...neutralizedThreatIds.map((id) => `THREAT DOWN: ${id} neutralized by defenders`),
+    );
+  }
 
   if (killedAgentIds.length > 0) {
     const killedSet = new Set(killedAgentIds);
@@ -572,6 +578,7 @@ function runTick(
   newKnownResources: Position[];
   newThreatSightings: ThreatSighting[];
   killedAgentIds: string[];
+  neutralizedThreatIds: string[];
 } {
   const newKnownResources: Position[] = [];
   const newThreatSightings: ThreatSighting[] = [];
@@ -602,7 +609,20 @@ function runTick(
   // Apply actions
   let resourcesCollected = 0;
   for (const action of actions) {
-    resourcesCollected += applyAction(action, agents, map, tick, pendingEpisodes);
+    resourcesCollected += applyAction(action, agents, map, tick, pendingEpisodes, threats);
+  }
+
+  const neutralizedThreatIds = threats
+    .filter((threat) => threat.hp <= 0)
+    .map((threat) => threat.id);
+
+  if (neutralizedThreatIds.length > 0) {
+    const neutralizedSet = new Set(neutralizedThreatIds);
+    for (let i = threats.length - 1; i >= 0; i--) {
+      if (neutralizedSet.has(threats[i].id)) {
+        threats.splice(i, 1);
+      }
+    }
   }
 
   // Move threats toward agents
@@ -630,6 +650,7 @@ function runTick(
     newKnownResources,
     newThreatSightings,
     killedAgentIds,
+    neutralizedThreatIds,
   };
 }
 

--- a/server/src/engine/agent-logic.ts
+++ b/server/src/engine/agent-logic.ts
@@ -130,6 +130,9 @@ function findNearestThreat(from: Position, threats: Threat[], maxRange: number):
   return nearest;
 }
 
+const DEFENDER_ATTACK_RANGE = 1;
+const DEFENDER_ATTACK_DAMAGE = 1;
+
 export const THREAT_SIGHTING_EXPIRY_TICKS = 20;
 
 function isThreatSightingFresh(sighting: ThreatSighting, tick: number): boolean {
@@ -606,6 +609,25 @@ function executeDefender(
       });
     }
 
+    if (threatDist <= DEFENDER_ATTACK_RANGE) {
+      const chaseTask = `chase:${visibleThreat.id}`;
+      const sameTarget = agent.workingMemory.currentTask === chaseTask;
+      agent.workingMemory.currentTask = chaseTask;
+      agent.workingMemory.taskTarget = visibleThreat.position;
+      if (!sameTarget) agent.workingMemory.taskStartTick = tick;
+
+      return {
+        agentId: agent.id,
+        agentType: "defender",
+        action: "attack",
+        reason: `Attacking threat ${visibleThreat.id} at (${visibleThreat.position.x}, ${visibleThreat.position.y})`,
+        from: agent.position,
+        to: { ...visibleThreat.position },
+        targetThreatId: visibleThreat.id,
+        doctrineVersion: doctrine.version,
+      };
+    }
+
     if (cfg.chaseThreats && threatDist <= cfg.maxChaseDistance) {
       // Commit to chasing via working memory; reset start tick only when switching to a different
       // threat. Compare by threat ID (not position) — threats move each tick so position-based
@@ -753,6 +775,7 @@ export function applyAction(
   map: GameMap,
   tick: number,
   pendingEpisodes: Array<{ agentId: string; record: EpisodeRecord }>,
+  threats: Threat[] = [],
 ): number {
   const agent = agents.find((a) => a.id === action.agentId);
   if (!agent) return 0;
@@ -821,6 +844,38 @@ export function applyAction(
     case "guard":
       agent.status = "defending";
       break;
+
+    case "attack": {
+      agent.status = "attacking";
+      if (!action.targetThreatId) break;
+
+      const threat = threats.find((candidate) => candidate.id === action.targetThreatId);
+      if (!threat || threat.hp <= 0) break;
+
+      threat.hp = Math.max(0, threat.hp - DEFENDER_ATTACK_DAMAGE);
+
+      if (threat.hp === 0) {
+        pendingEpisodes.push({
+          agentId: agent.id,
+          record: {
+            tick,
+            eventType: "threat-neutralized",
+            position: { ...threat.position },
+            detail: `Neutralized ${threat.id} at (${threat.position.x}, ${threat.position.y})`,
+          },
+        });
+
+        if (
+          agent.workingMemory.currentTask === `chase:${threat.id}` ||
+          agent.workingMemory.currentTask === `investigate:${threat.id}`
+        ) {
+          agent.workingMemory.currentTask = null;
+          agent.workingMemory.taskTarget = null;
+          agent.workingMemory.taskStartTick = null;
+        }
+      }
+      break;
+    }
 
     case "idle":
       agent.status = "idle";

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -44,7 +44,8 @@ export type EpisodeEventType =
   | "resource-depleted"
   | "task-completed"
   | "threat-spotted"
-  | "damage-taken";
+  | "damage-taken"
+  | "threat-neutralized";
 
 /** A single recorded observation (Tier 2: Episodic Memory) */
 export interface EpisodeRecord {
@@ -66,7 +67,7 @@ export interface MemoryConfig {
 
 export type AgentType = "gatherer" | "scout" | "defender";
 
-export type AgentStatus = "idle" | "moving" | "gathering" | "depositing" | "scouting" | "defending" | "returning";
+export type AgentStatus = "idle" | "moving" | "gathering" | "depositing" | "scouting" | "defending" | "returning" | "attacking";
 
 export interface Agent {
   id: string;
@@ -94,7 +95,7 @@ export interface Agent {
 
 // --- Threats ---
 
-/** A hostile unit that wanders and damages agents */
+/** A hostile unit that pursues agents and can be neutralized by defenders. */
 export interface Threat {
   id: string;
   position: Position;
@@ -224,6 +225,7 @@ export interface AgentAction {
   reason: string;
   from: Position;
   to: Position | null;
+  targetThreatId?: string;
   /** Which doctrine version the agent used for this decision */
   doctrineVersion: number;
 }


### PR DESCRIPTION
## Summary
- add a lightweight defender melee attack so threats can be neutralized instead of remaining one-sided hazards
- surface threat neutralization clearly in the debrief UI and expand tests around tick resolution and combat behavior
- update project docs to reflect the shipped combat model and the preference for manual ticks during gameplay verification

## Verification
- pnpm --filter @doctrine/server test
- pnpm typecheck
- manual tick verification with agent-browser confirmed the `THREAT DOWN` debrief card appears